### PR TITLE
Fix non-profit , change year

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -186,9 +186,7 @@
               another priority. Nicolas Dorier, founder of the BTCPay Server Project, shall possess two votes for the
               purpose of breaking a tie.</p>
 
-            <p>BTCPay Server Foundation is not a
-              501(c)(3) organisation. If you have questions about the tax consequences of donating, please consult a tax
-              professional.</p>
+            <p>BTCPay Server Foundation is a non-profit organization.
           </div>
 
 
@@ -236,7 +234,7 @@
           <p class="copyright_">
             <!--<a class="nullTrans" alt="Flat 18 Microsystems Development LLC << FLAT18.CO.UK >>"
             href="https://flat18.co.uk">Website built with ⚡ by FLAT18.CO.UK</a>-->
-            © 2019 BTCPay Server Foundation
+            © 2020 BTCPay Server Foundation
             <br> This website does not use cookies<br></p>
         </div>
       </footer>

--- a/about-us.html
+++ b/about-us.html
@@ -186,7 +186,7 @@
               another priority. Nicolas Dorier, founder of the BTCPay Server Project, shall possess two votes for the
               purpose of breaking a tie.</p>
 
-            <p>BTCPay Server Foundation is a non-profit organization.
+            <p>BTCPay Server Foundation is a non-profit organization.</p>
           </div>
 
 


### PR DESCRIPTION
Foundation is now a proper non-profit organization. 
This PR removes the mention of earlier non 501(3) disclaimer and fixes the year in footer to 2020.